### PR TITLE
Fix compatibility with NumPy 1.17 and 1.18

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ An example of computing the square of a two-dimensional vector with Gyrus:
 This code is automagically converted to `Nengo <http://nengo.ai/>`_ and implemented
 via two spiking LIF ensembles and a lowpass synapse.
 
-Gyrus supports many common Numpy 'ufuncs', array functions, and numeric Python
+Gyrus supports many common NumPy 'ufuncs', array functions, and numeric Python
 operators. Thus, code can be written in a functional style using N-D arrays and then
 realized as a Nengo neural network. This enables algorithms to be written in NumPy and
 then compiled onto `Nengo's supported backends <https://www.nengo.ai/documentation/>`_

--- a/docs/examples/gyrus_overview.ipynb
+++ b/docs/examples/gyrus_overview.ipynb
@@ -249,7 +249,7 @@
     "assert y.size_out == d\n",
     "\n",
     "out = np.asarray(y.run(1))\n",
-    "out.shape  # (outputs, time, size_out)"
+    "out.shape  # shape: (time, size_out)"
    ]
   },
   {

--- a/gyrus/auto.py
+++ b/gyrus/auto.py
@@ -187,9 +187,9 @@ def vectorize(
         # be vectorized by np.vectorize as it also looks for __len__ to determine
         # whether to vectorize an element, which is currently supported by Fold
         # but not Operator.
-        vectorized = np.vectorize(
-            instantiate, otypes=[cls], *vectorize_args, **vectorize_kwargs
-        )
+        # TODO: Ideally we would specify otypes=[cls] but this fails due to a bug
+        #  in earlier versions of NumPy: https://github.com/numpy/numpy/issues/16120.
+        vectorized = np.vectorize(instantiate, *vectorize_args, **vectorize_kwargs)
 
         # The actual implementation (i.e., the returned wrapper) does the vectorization
         # and then converts the array output into a Fold -- unless it is just a single

--- a/gyrus/base.py
+++ b/gyrus/base.py
@@ -168,7 +168,7 @@ class Fold(Operator):
     @cached_property
     def array(self):
         """Returns the structure of input operators as an immutable NumPy array."""
-        arr = np.asarray(self, dtype=type(self))
+        arr = np.asarray(self.input_ops, dtype=type(self))
         arr.flags.writeable = False  # safety precaution
         return arr
 

--- a/gyrus/optional.py
+++ b/gyrus/optional.py
@@ -41,7 +41,10 @@ def tensor_node(
         fail_msg="nengo_dl.TensorNode is required by the 'tensor_node' operator",
     )
     out = nengo_dl.TensorNode(
-        tensor_func, shape_in=(node.size_out,), shape_out=shape_out, pass_time=pass_time
+        tensor_func,
+        shape_in=(node.size_out,),
+        shape_out=shape_out,
+        pass_time=bool(pass_time),  # https://github.com/nengo/nengo/issues/1667
     )
     nengo.Connection(node, out, synapse=None)
     return out


### PR DESCRIPTION
Fixes #5. There were a combination of two issues:
    
1. `otypes` cannot be passed to `np.vectorize` if there are kwargs (https://github.com/numpy/numpy/issues/16120).
    
2. Older versions of `np.asarray(arr_like, ...)` will perform slicing on `arr_like` in a way that results in infinite recursion.